### PR TITLE
Delegate to ILocalPortletAssignmentManager for category blacklist retrieval.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Delegate to ILocalPortletAssignmentManager for category blacklist retrieval.
+  This allows a custom adapter to override the default blacklist settings per
+  portlet manager.
+  [elro]
 
 
 2.1 (2012-07-02)


### PR DESCRIPTION
Before I commit and release this, I wanted to check with @optilude and @malthe (and anyone else interested) that this looks like a sane improvement to allow for non-inheriting portlet managers:

This allows a custom adapter to override the default blacklist settings per portlet manager. For instance, to make a porlet manager default to blocking contextual portlets, create an LPAM adapter subclass like:

```
class DefaultUninheritable(LocalPortletAssignmentManager):
    """By default Plone allows portlets to be inherited from the parent
    """
    def getBlacklistStatus(self, category):
        value = super(DefaultUninheritable, self).getBlacklistStatus(category)
        if category is CONTEXT_CATEGORY and value is None:
            return True
        return value
```

And register with:

```
<adapter
  factory=".DefaultUninheritable"
  for="plone.portlets.interfaces.ILocalPortletAssignable
       ..interfaces.ICarousel"
  />
```
